### PR TITLE
[Unity]优化DataTranslate的委托处理函数中频繁的反射性能消耗

### DIFF
--- a/unity/Assets/Puerts/Src/ArgumentHelper.cs
+++ b/unity/Assets/Puerts/Src/ArgumentHelper.cs
@@ -206,15 +206,60 @@ namespace Puerts
             return (new DateTime(1970, 1, 1)).AddMilliseconds(ticks);
         }
 
+        public ArrayBuffer GetArrayBuffer(bool isByRef)
+        {
+            if (obj != null) return (ArrayBuffer)obj;
+            obj = JsEnv.jsEnvs[jsEnvIdx].GeneralGetterManager.GetArrayBufferTranslatorFunc(isolate, NativeValueApi.GetValueFromArgument, value, isByRef);
+            if (obj != null)
+            {
+                return (ArrayBuffer)obj;
+            }
+            return default(ArrayBuffer);
+        }
+        
+        public GenericDelegate GetGenericDelegate(bool isByRef)
+        {
+            if (obj != null) return (GenericDelegate)obj;
+            obj = JsEnv.jsEnvs[jsEnvIdx].GeneralGetterManager.GetGenericDelegateTranslatorFunc(isolate, NativeValueApi.GetValueFromArgument, value, isByRef);
+            if (obj != null)
+            {
+                return (GenericDelegate)obj;
+            }
+            return default(GenericDelegate);
+        }
+        
+        public JSObject GetJSObject(bool isByRef)
+        {
+            if (obj != null) return (JSObject)obj;
+            obj = JsEnv.jsEnvs[jsEnvIdx].GeneralGetterManager.GetJSObjectTranslatorFunc(isolate, NativeValueApi.GetValueFromArgument, value, isByRef);
+            if (obj != null)
+            {
+                return (JSObject)obj;
+            }
+            return default(JSObject);
+        }
+
+        public object GetSystemObject(bool isByRef)
+        {
+            if (obj != null) return obj;
+            return JsEnv.jsEnvs[jsEnvIdx].GeneralGetterManager.GetAnyTranslatorFunc(isolate, NativeValueApi.GetValueFromArgument, value, isByRef);
+        }
+
         public void SetByRefValue(DateTime val)
         {
             PuertsDLL.SetDateToOutValue(isolate, value, (val - new DateTime(1970, 1, 1)).TotalMilliseconds);
         }
 
-        public T Get<T>(bool isByRef)
+        public T GetRefType<T>(bool isByRef)
         {
             if (obj != null) return (T)obj;
             return StaticTranslate<T>.Get(jsEnvIdx, isolate, NativeValueApi.GetValueFromArgument, value, isByRef);
+        }
+        
+        public T GetNonRefType<T>(bool isByRef)
+        {
+            if (obj != null) return (T)obj;
+            return StaticTranslate<T>.GetNonRefTranslator(jsEnvIdx, isolate, NativeValueApi.GetValueFromArgument, value, isByRef);
         }
 
         public T[] GetParams<T>(IntPtr info, int start, int end)

--- a/unity/Assets/Puerts/Src/Editor/Resources/puerts/templates/type.tpl.txt
+++ b/unity/Assets/Puerts/Src/Editor/Resources/puerts/templates/type.tpl.txt
@@ -15,6 +15,10 @@ const fixGet = {
     bool: 'GetBoolean',
     string: 'GetString',
     DateTime: 'GetDateTime',
+    'Puerts.ArrayBuffer': 'GetArrayBuffer',
+    'Puerts.GenericDelegate': 'GetGenericDelegate',
+    'Puerts.JSObject': 'GetJSObject',
+    'System.Object': 'GetSystemObject',
 };
 const fixReturn = {
     char: 'Puerts.PuertsDLL.ReturnNumber(isolate, info, result)',
@@ -98,7 +102,11 @@ function getArgument(typeInfo, argHelper, idx) {
     } else if (typeName in fixGet) {
         return `${argHelper}.${fixGet[typeName]}(${isByRef})`;
     } else {
-        return `${argHelper}.Get<${typeName}>(${isByRef})`;
+        if (typeInfo.IsByRef) {
+            return `${argHelper}.GetRefType<${typeName}>(${isByRef})`;
+        } else if (!typeInfo.IsEnum){
+            return `${argHelper}.GetNonRefType<${typeName}>(${isByRef})`;
+        }
     }
 }
 function setReturn(typeInfo) {

--- a/unity/Assets/Puerts/Src/StaticTranslate.cs
+++ b/unity/Assets/Puerts/Src/StaticTranslate.cs
@@ -42,6 +42,16 @@ namespace Puerts
             Set = pushFunc;
             Get = getFunc;
         }
+
+        public static T GetNonRefTranslator(int jsEnvIdx, IntPtr isolate, IGetValueFromJs getValueApi, IntPtr value, bool isByRef)
+        {
+            object obj = JsEnv.jsEnvs[jsEnvIdx].GeneralGetterManager.GetNativeObjectTranslatorFunc(isolate, getValueApi, value, isByRef);
+            if (obj != null)
+            {
+                return (T)obj;
+            }
+            return default(T);
+        }
     }
 
     public static class PrimitiveTypeTranslate


### PR DESCRIPTION
优化DataTranslate的委托处理函数中频繁的反射性能消耗，生成代码中提前判断参数类型